### PR TITLE
Config: load erb files.

### DIFF
--- a/lib/rails-assets-cdn/rails-assets-cdn.rb
+++ b/lib/rails-assets-cdn/rails-assets-cdn.rb
@@ -6,10 +6,10 @@ module RailsAssetsCdn
 
       config = nil
       %w(assets_cdn.yml cdn.yml).each do |filename|
-        config_path = Rails.root.join('config', filename).to_s
+        config_path = Rails.root.join('config', filename)
         if File.exist?(config_path)
           Rails.logger.info "  Reading config file at #{config_path}..."
-          config = YAML.load_file(config_path)[Rails.env]
+          config = YAML.load(ERB.new(File.read(config_path)).result)[Rails.env]
           break
         end
       end


### PR DESCRIPTION
On Heroku you only have the production environment. If you'd like to use
staging it will always take from the production section in your yaml
file.

Using an erb file we make it possible to add some logic to that file and
thus enable us to have different hosts on production/staging.

I've got this from https://github.com/bernardogalindo/rails-assets-cdn/commit/1b08ef9d69d0f4482ba418d5b8fa0f4994a3b828 but he didn't seem to put in a PR.
